### PR TITLE
feat: add support for amazon purchases new response field

### DIFF
--- a/src/server/handlers/mcp-handler.ts
+++ b/src/server/handlers/mcp-handler.ts
@@ -27,7 +27,7 @@ const McpResponse = z.object({
         content: z.union([
           // wayfair response unparsed string
           z.string(),
-          // amazon, officedepot is parsed
+          // officedepot is parsed
           z.array(z.record(z.unknown())),
         ]),
       })
@@ -35,6 +35,8 @@ const McpResponse = z.object({
     .optional(),
   // goodreads response
   books: z.array(z.record(z.unknown())).optional(),
+  // amazon response
+  purchases: z.array(z.record(z.unknown())).optional(),
 });
 
 type PurchaseHistoryResponse = {
@@ -73,13 +75,19 @@ export const handlePurchaseHistory = async (req: Request, res: Response) => {
   };
 
   // didn't have any content
-  if (!mcpResponse.extract_result?.[0]?.content && !mcpResponse.books?.length) {
+  if (
+    !mcpResponse.extract_result?.[0]?.content &&
+    !mcpResponse.books?.length &&
+    !mcpResponse.purchases?.length
+  ) {
     res.json(response);
     return;
   }
 
   const rawContent =
-    mcpResponse.extract_result?.[0]?.content || mcpResponse.books;
+    mcpResponse.extract_result?.[0]?.content ||
+    mcpResponse.books ||
+    mcpResponse.purchases;
 
   if (typeof rawContent === 'string') {
     response.content = JSON.parse(rawContent);


### PR DESCRIPTION
## Summary

  This PR adds support for handling Amazon purchase data through a dedicated \`purchases\` field in the MCP 
  response schema, improving the structure and clarity of response handling for different e-commerce brands.

  ## Changes

  - Added \`purchases\` field to \`McpResponse\` zod schema for Amazon-specific responses
  - Updated comment to clarify that only Office Depot uses the parsed array format in \`extract_result\`
  - Extended content validation logic to check for \`purchases\` field
  - Updated content extraction logic to include \`purchases\` as a fallback option

  ## Additional Notes

  This change prepares the codebase for eventual deprecation of the generic \`extract_result\` field by 
  introducing brand-specific response fields. The \`purchases\` field follows the same pattern as the 
  existing \`books\` field for Goodreads, making the response structure more explicit and maintainable."