### PR TITLE
fix: pass client IP to MCP client manager

### DIFF
--- a/src/server/handlers/mcp-handler.ts
+++ b/src/server/handlers/mcp-handler.ts
@@ -116,7 +116,8 @@ export const handlePurchaseHistoryDetails = async (
     return;
   }
 
-  const mcpClient = await mcpClientManager.get(req.sessionID);
+  const clientIp = geolocationService.getClientIp(req);
+  const mcpClient = await mcpClientManager.get(req.sessionID, clientIp);
   const result = await mcpClient.callTool({
     name: tools[brandName][1],
     arguments: { order_id: orderId },


### PR DESCRIPTION
This PR fixes the MCP handler to properly pass the client IP address to the MCP client manager.

